### PR TITLE
Fix topic header text

### DIFF
--- a/app/assets/stylesheets/components/topics.css
+++ b/app/assets/stylesheets/components/topics.css
@@ -89,6 +89,12 @@
   }
 }
 
+.topic-meta {
+  & span {
+    padding-right: var(--spacing-2);
+  }
+}
+
 .topic-link {
   color: var(--color-text-link);
   text-decoration: none;


### PR DESCRIPTION
This commit fixes the sub title text of a topic header, where before this commit the text would look like:

```
Started by Bob Committer10 days ago14 messages
```

and after this commit looks like:

```
Started by Bob Committer 10 days ago 14 messages
```