### PR TITLE
Add absolute time info as hover over of elapsed time text

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,6 +18,11 @@ module ApplicationHelper
     end
   end
 
+  def absolute_time_display(time)
+    return "" if time.nil?
+    time.strftime("%B %d, %Y at %I:%M %p")
+  end
+
   def render_message_body(body)
     QuotedEmailFormatter.new(body.to_s).to_html.html_safe
   end

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -16,7 +16,7 @@
       .activity-card class=("is-unread" if activity.read_at.nil?)
         .activity-meta
           span.activity-type = activity.activity_type.humanize
-          span.activity-time = smart_time_display(activity.created_at)
+          span.activity-time title=absolute_time_display(activity.created_at) = smart_time_display(activity.created_at)
           - if activity.read_at.nil?
             span.activity-unread-badge Unread
 

--- a/app/views/topics/_message.html.slim
+++ b/app/views/topics/_message.html.slim
@@ -19,7 +19,7 @@
           .author-email = message.sender.email
     .message-meta
       .message-date
-        time datetime=message.created_at.iso8601 title=message.created_at.strftime("%B %d, %Y at %I:%M %p")
+        time datetime=message.created_at.iso8601 title=absolute_time_display(message.created_at)
           = time_ago_in_words(message.created_at)
           |  ago
       - if message.reply_to

--- a/app/views/topics/_topics.html.slim
+++ b/app/views/topics/_topics.html.slim
@@ -16,7 +16,7 @@
       - last_message = topic.messages.order(:created_at).last
       .activity-info
         .activity-replies = "#{topic.messages.count - 1} replies"
-        .activity-time = smart_time_display(last_message.created_at)
+        .activity-time title=absolute_time_display(last_message.created_at) = smart_time_display(last_message.created_at)
     - if user_signed_in?
       - state = @topic_states&.dig(topic.id) || {}
       - status = state[:status]

--- a/app/views/topics/_topics_page.html.slim
+++ b/app/views/topics/_topics_page.html.slim
@@ -32,7 +32,7 @@
     .topic-column.activity-col
       - last_message = topic.messages.order(:created_at).last
       .activity-info
-        .activity-time = time_ago_in_words(last_message.created_at) + " ago"
+        .activity-time title=absolute_time_display(last_message.created_at) = time_ago_in_words(last_message.created_at) + " ago"
         small.activity-author by #{last_message.sender.name}
 
 / Next page Turbo Frame for infinite scroll


### PR DESCRIPTION
This commit adds the support to show the absolute time when the user moves the mouse cursor over an elapsed time text that is present in the topics list, or in each message header.