### PR TITLE
Split mentions and tagging from the actual notes

### DIFF
--- a/app/assets/stylesheets/components/notes.css
+++ b/app/assets/stylesheets/components/notes.css
@@ -107,6 +107,25 @@
   margin-bottom: var(--spacing-2);
 }
 
+.note-form-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.note-meta-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--spacing-3);
+}
+
+.note-field label {
+  display: block;
+  font-weight: var(--font-weight-medium);
+  margin-bottom: var(--spacing-1);
+  color: var(--color-text-primary);
+}
+
 .note-textarea {
   width: 100%;
   border-radius: var(--border-radius-sm);
@@ -114,6 +133,21 @@
   padding: var(--spacing-2);
   font-family: var(--font-family-base);
   font-size: var(--font-size-base);
+}
+
+.note-text-field {
+  width: 100%;
+  border-radius: var(--border-radius-sm);
+  border: var(--border-width) solid var(--color-border);
+  padding: var(--spacing-2);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-base);
+}
+
+.note-hint {
+  margin-top: 4px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
 }
 
 .note-actions {

--- a/app/views/notes/_form.html.slim
+++ b/app/views/notes/_form.html.slim
@@ -3,18 +3,33 @@
 - note_error = flash[:note_error]&.with_indifferent_access
 
 - prefill_body = form_note.body
+- prefill_tags = form_note.note_tags.map(&:tag).join(", ")
+- prefill_mentions = form_note.note_mentions.includes(:mentionable).map { |mention| note_mention_label(mention) }.join(", ")
 - if note_error
   - matches_note = note_error[:note_id].present? && form_note.persisted? && form_note.id == note_error[:note_id].to_i
   - matches_new_note = !form_note.persisted? && note_error[:topic_id].to_i == topic.id && note_error[:message_id].to_s == message&.id.to_s
   - if matches_note || matches_new_note
     - prefill_body = note_error[:body]
+    - prefill_tags = note_error[:tags_input].to_s
+    - prefill_mentions = note_error[:mentions_input].to_s
 
 = form_with model: form_note, url: form_note.persisted? ? note_path(form_note) : notes_path, method: form_note.persisted? ? :patch : :post, data: { turbo: true } do |f|
   = hidden_field_tag "note[topic_id]", topic.id
   = hidden_field_tag "note[message_id]", message&.id
-  .note-field
-    = f.text_area :body, rows: 3, placeholder: "Add a note with @mentions and #tags…", required: true, class: "note-textarea", value: prefill_body
-    - if note_error && prefill_body == note_error[:body]
-      .note-error = note_error[:error]
+  .note-form-fields
+    .note-field
+      = f.label :body, "Note"
+      = f.text_area :body, rows: 4, placeholder: "Write your note", required: true, class: "note-textarea", value: prefill_body
+      - if note_error && prefill_body == note_error[:body]
+        .note-error = note_error[:error]
+    .note-meta-fields
+      .note-field
+        = label_tag :note_mentions_input, "Mentions"
+        = text_field_tag "note[mentions_input]", prefill_mentions, placeholder: "@alice, @team", class: "note-text-field"
+        .note-hint "Notify people or teams. Separate with commas or spaces."
+      .note-field
+        = label_tag :note_tags_input, "Tags"
+        = text_field_tag "note[tags_input]", prefill_tags, placeholder: "release, docs, follow-up", class: "note-text-field"
+        .note-hint "Optional tags for filtering. Lowercase letters, numbers, dash, underscore, or dot."
   .note-actions
     = f.submit submit_label, class: "button-secondary"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -913,48 +913,56 @@ carol_notes = NoteBuilder.new(author: carol_user)
 alice_notes.create!(
   topic: patch_topic,
   message: msg3,
-  body: "- Add WAL position to progress report\n- Split heap vs index counters\n- Autovacuum should emit too\n@ExampleCompany please sync on scope"
+  body: "- Add WAL position to progress report\n- Split heap vs index counters\n- Autovacuum should emit too\nExampleCompany please sync on scope",
+  mention_names: [example_team.name]
 )
 bob_notes.create!(
   topic: patch_topic,
   message: msg1,
-  body: "Queued for next CF round; tracking in CF app.\n@ExampleCompany heads-up for review bandwidth"
+  body: "Queued for next CF round; tracking in CF app.\nExampleCompany heads-up for review bandwidth",
+  mention_names: [example_team.name]
 )
 
 # RFC thread notes (thread + message, different authors)
 carol_notes.create!(
   topic: rfc_topic,
-  body: "Thread summary: add index AM hooks, include sample AM + docs.\n@ExampleCompany track follow-ups"
+  body: "Thread summary: add index AM hooks, include sample AM + docs.\nExampleCompany track follow-ups",
+  mention_names: [example_team.name]
 )
 alice_notes.create!(
   topic: rfc_topic,
   message: rfc_msg2,
-  body: "Docs + sample AM needed before commit. Add SGML + README.\n@ExampleCompany can we help draft?"
+  body: "Docs + sample AM needed before commit. Add SGML + README.\nExampleCompany can we help draft?",
+  mention_names: [example_team.name]
 )
 
 # Discussion thread: mix of thread/message notes from different people
 carol_notes.create!(
   topic: discussion_topic,
-  body: "Thread note: align logical slots with failover, add standby-safe flag.\n@ExampleCompany capture design risks"
+  body: "Thread note: align logical slots with failover, add standby-safe flag.\nExampleCompany capture design risks",
+  mention_names: [example_team.name]
 )
 alice_notes.create!(
   topic: discussion_topic,
   message: disc_msg4,
-  body: "Message note: prototype slot fencing, watch cascading setups; prefer heartbeat piggyback.\n@ExampleCompany please review"
+  body: "Message note: prototype slot fencing, watch cascading setups; prefer heartbeat piggyback.\nExampleCompany please review",
+  mention_names: [example_team.name]
 )
 
 # Committer topic: partially read with a note
 bob_notes.create!(
   topic: committer_topic,
   message: committer_messages[3],
-  body: "Action: test lower freeze_age under heavy autovacuum.\n@ExampleCompany check lab capacity"
+  body: "Action: test lower freeze_age under heavy autovacuum.\nExampleCompany check lab capacity",
+  mention_names: [example_team.name]
 )
 
 # Moderate topic note for visibility
 carol_notes.create!(
   topic: moderate_topic_1,
   message: moderate_msgs_1[5],
-  body: "Pooling experiments look good; consider adaptive target.\n@ExampleCompany let's benchmark with PG16"
+  body: "Pooling experiments look good; consider adaptive target.\nExampleCompany let's benchmark with PG16",
+  mention_names: [example_team.name]
 )
 
 # Notes on extra sampler topics for visibility across pages

--- a/spec/services/note_builder_spec.rb
+++ b/spec/services/note_builder_spec.rb
@@ -11,7 +11,13 @@ RSpec.describe NoteBuilder do
     team_member = create(:user, username: "carl")
     create(:team_member, team:, user: team_member)
 
-    note = described_class.new(author: author).create!(topic:, message:, body: "Ping @bob and @team-two #Foo #bar")
+    note = described_class.new(author: author).create!(
+      topic:,
+      message:,
+      body: "Ping for review",
+      tags: %w[foo bar],
+      mention_names: %w[bob team-two]
+    )
 
     expect(note.note_tags.pluck(:tag)).to match_array(%w[foo bar])
     expect(note.note_mentions.map(&:mentionable)).to match_array([mentioned_user, team])
@@ -30,8 +36,8 @@ RSpec.describe NoteBuilder do
     carol = create(:user, username: "carol")
 
     builder = described_class.new(author: author)
-    note = builder.create!(topic:, message:, body: "Hi @bob and @devs")
-    builder.update!(note:, body: "Hi @bob and @carol")
+    note = builder.create!(topic:, message:, body: "Hi team", mention_names: %w[bob devs])
+    builder.update!(note:, body: "Hi friends", mention_names: %w[bob carol])
 
     old_activity = Activity.find_by(user: dev_member, subject: note)
     new_activity = Activity.find_by(user: carol, subject: note)


### PR DESCRIPTION
This splits the mentions and tagging into subitems/input boxes, which allows us later to support markdown or other stuff for the notes directly, as these are seperate. 