### PR TITLE
Add attached patches to message view

### DIFF
--- a/app/assets/stylesheets/components/messages.css
+++ b/app/assets/stylesheets/components/messages.css
@@ -224,9 +224,13 @@
 
 .attachment-info {
   display: flex;
-  gap: var(--spacing-3);
   align-items: center;
   font-size: var(--font-size-sm);
+}
+
+summary.attachment-info {
+  cursor: pointer;
+  display: list-item;
 }
 
 .filename {
@@ -236,6 +240,7 @@
 
 .content-type {
   color: var(--color-text-muted);
+  margin-left: var(--spacing-3);
 }
 
 .import-metadata {

--- a/app/views/topics/_message.html.slim
+++ b/app/views/topics/_message.html.slim
@@ -41,10 +41,19 @@
       .message-attachments
         h4 Attachments:
         - message.attachments.each do |attachment|
-          .attachment
-            .attachment-info
-              span.filename = attachment.file_name
-              span.content-type = attachment.content_type if attachment.content_type
+          - if attachment.patch?
+            details class="attachment"
+              summary class="attachment-info"
+                span.filename = attachment.file_name
+                span.content-type = attachment.content_type if attachment.content_type
+              pre class="attachment-content"
+                code class="language-diff"
+                  = attachment.decoded_body
+          - else
+            .attachment
+              .attachment-info
+                span.filename = attachment.file_name
+                span.content-type = attachment.content_type if attachment.content_type
 
   - if message.import_log.present?
     .import-metadata


### PR DESCRIPTION
Also let the user expand/collapse them by clicking.

This is just the fundamentals, we need to do more with it before it's useful. If I pick this up again I'll try to use highlight.js to add some colors to the diffs and some css to make it all look good.