### PR TITLE
Fix legend color in statistics view

### DIFF
--- a/app/assets/stylesheets/components/stats.css
+++ b/app/assets/stylesheets/components/stats.css
@@ -126,6 +126,7 @@
   border: var(--border-width) solid var(--color-border);
   border-radius: var(--border-radius-md);
   padding: var(--spacing-2);
+  color: var(--color-text-primary);
 }
 
 .series-grid {


### PR DESCRIPTION
Right now the legend color isn't visible in dark theme, but with this change, the color will be changed to the primary text color, which is white or back to black for the light theme automatically. 