### PR TITLE
Sidebar now scrolls independently

### DIFF
--- a/app/assets/stylesheets/components/sidebar.css
+++ b/app/assets/stylesheets/components/sidebar.css
@@ -2,6 +2,9 @@
   position: sticky;
   top: calc(var(--nav-height) + var(--spacing-5));
   align-self: start;
+  max-height: calc(100vh - var(--nav-height) - var(--spacing-5));
+  overflow-y: auto;
+  padding-right: var(--spacing-2);
 }
 
 .sidebar-section {


### PR DESCRIPTION
Sidebar now scrolls independently, so long threads don’t trap the sidebar until the main content reaches its end.

This is currently an issue with long threads, as you might have to scroll 100 messages until the sidebar catches up. This is cumbersome, as you might simply want to jump to a spefcific message using the outline or looking at a specific patch which is currently not easily doable with doomscrolling. 