### PR TITLE
This fixes the sidebar on mobile view

### DIFF
--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -15,6 +15,7 @@ export default class extends Controller {
     this.handleDocumentClick = this.handleDocumentClick.bind(this)
     window.addEventListener("resize", this.handleWindowResize)
     document.addEventListener("click", this.handleDocumentClick)
+    this.wasMobile = this.isMobile()
 
     if (!this.hasLayoutTarget || !this.hasSidebarTarget) {
       return
@@ -86,8 +87,12 @@ export default class extends Controller {
   }
 
   handleWindowResize() {
-    if (this.isMobile()) {
+    const isMobile = this.isMobile()
+    if (this.wasMobile && !isMobile) {
       this.closeMobile()
+    }
+    this.wasMobile = isMobile
+    if (isMobile) {
       return
     }
 


### PR DESCRIPTION
This fixes the sidebar on mobile view, as it stops hiding the sidebar on every size change, as the displaying of the keyboard, changes the viewable size, but should not collapse the sidebar again, as otherwise a search is impossible