### PR TITLE
Show actual from address of non-user messages

### DIFF
--- a/app/views/topics/_message.html.slim
+++ b/app/views/topics/_message.html.slim
@@ -31,7 +31,7 @@
             .author-name = link_to display_alias.name, profile_path, class: "author-name-link"
           - else
             .author-name = display_alias.name
-          .author-email = display_alias.email
+          .author-email = message.sender_person.user ? display_alias.email : message.sender.email
     .message-meta
       .message-date
         time datetime=message.created_at.iso8601 title=absolute_time_display(message.created_at)


### PR DESCRIPTION
Registered users have probably set their default email address to something reasonable, but for non-users it's jarring to see an email address that most likely haven't been valid in many years when reading a message they sent recently.

Example: https://hackorum.dev/topics/53153

An alternative would be to make sure the default alias for non-users is the latest one, but that could also be weird in case they send a sporadic email from an address that isn't their main.