### PR TITLE
Display mailing list badges in a separate column

### DIFF
--- a/app/assets/stylesheets/components/topics.css
+++ b/app/assets/stylesheets/components/topics.css
@@ -125,6 +125,7 @@ body.sidebar-collapsed .topics-table th.topic-title .sidebar-burger-button {
   & .topic-replies {
     width: 100px;
   }
+  & .topic-mailing-lists,
   & .topic-activity {
     width: 150px;
   }
@@ -274,6 +275,7 @@ a.topic-icon {
     }
 
     & th.activity-header,
+    & th.mailing-lists-header,
     & td.topic-activity {
       display: none;
     }

--- a/app/views/topics/_status_cell.html.slim
+++ b/app/views/topics/_status_cell.html.slim
@@ -28,9 +28,6 @@ td.topic-title.status-border class=status_class id=dom_id(topic, "status_cell") 
     .topic-title-icons
       == icons_html
     span
-      - topic_lists = @topic_mailing_lists_map&.dig(topic.id) || []
-      - if topic_lists.any?
-        = mailing_list_badges_html(topic_lists)
       = link_to topic.title, topic_title_link(topic), class: "topic-link"
   .topic-title-mobile
     = link_to topic.title, topic_title_link(topic), class: "topic-link"

--- a/app/views/topics/_topics.html.slim
+++ b/app/views/topics/_topics.html.slim
@@ -14,6 +14,10 @@
 
   tr id=dom_id(topic) class="topic-row" data-topic-id=topic.id data-last-message-id=topic.last_message_id
     = render partial: "topics/status_cell", locals: { topic: topic, state: {}, note_count: 0, team_readers: [], star_data: {} }
+    td.topic-mailing-lists data-label="Mailing Lists"
+      - topic_lists = @topic_mailing_lists_map&.dig(topic.id) || []
+      - if topic_lists.any?
+        = mailing_list_badges_html(topic_lists)
     td.topic-activity data-label="Activity"
       - replies_count = [topic.message_count - 1, 0].max
       .activity-info.compact

--- a/app/views/topics/index.html.slim
+++ b/app/views/topics/index.html.slim
@@ -10,6 +10,7 @@
             button.sidebar-burger-button type="button" aria-label="Expand sidebar" data-action="click->sidebar#toggle"
               i.fa-solid.fa-bars aria-hidden="true"
             | Topic
+          th.mailing-lists-header Mailing Lists
           th.activity-header Activity
           th.participants-header Participants
       tbody#topics

--- a/app/views/topics/search.html.slim
+++ b/app/views/topics/search.html.slim
@@ -58,6 +58,7 @@
         thead
           tr
             th.topic-title Topic
+            th.mailing-lists-header Mailing Lists
             th.activity-header Activity
             th.participants-header Participants
         tbody#topics


### PR DESCRIPTION
Before:
<img width="2983" height="622" alt="Screenshot 2026-05-13 at 14 15 35" src="https://github.com/user-attachments/assets/7ff3cb75-1131-4b06-b1af-0b967a09ac47" />

After:
<img width="2989" height="624" alt="Screenshot 2026-05-13 at 14 15 21" src="https://github.com/user-attachments/assets/d96f9419-8503-4bec-849b-7bf77f772a0f" />

I don't like that mailing lists badges affect topics titles alignment.
Any thoughts?