### PR TITLE
Change margins of `Add note` textarea and button

### DIFF
--- a/app/assets/stylesheets/components/notes.css
+++ b/app/assets/stylesheets/components/notes.css
@@ -129,7 +129,7 @@
 }
 
 .note-field {
-  margin-bottom: var(--spacing-2);
+  margin: var(--spacing-2);
 }
 
 .note-textarea {
@@ -144,6 +144,11 @@
 .note-actions {
   display: flex;
   justify-content: flex-end;
+  margin: 0 var(--spacing-2);
+}
+
+.note-actions > input {
+  margin: 0;
 }
 
 .note-actions-row {


### PR DESCRIPTION
Before:
<img width="1956" height="546" alt="Screenshot 2026-05-16 at 21 10 14" src="https://github.com/user-attachments/assets/a8926545-d8c0-4a61-9af0-b52f979ec2ea" />

After:
<img width="1944" height="501" alt="Screenshot 2026-05-16 at 21 09 48" src="https://github.com/user-attachments/assets/cc584fb5-88af-44a6-af16-1c411ee8823b" />
