### PR TITLE
Moved and refactored the burger menue for the sidebar - solves #110

### DIFF
--- a/app/assets/stylesheets/components/navigation.css
+++ b/app/assets/stylesheets/components/navigation.css
@@ -22,6 +22,10 @@
   position: relative;
 }
 
+body.has-sidebar .nav-burger {
+  display: inline-flex;
+}
+
 .nav-burger {
   display: none;
   align-items: center;
@@ -349,10 +353,6 @@
 
   .nav-mobile-star + .nav-mobile-bell {
     margin-left: 0;
-  }
-
-  body.has-sidebar .nav-burger {
-    display: inline-flex;
   }
 
   .mobile-nav-dropdown {

--- a/app/assets/stylesheets/components/sidebar.css
+++ b/app/assets/stylesheets/components/sidebar.css
@@ -14,51 +14,6 @@
   justify-content: center;
 }
 
-.topics-table th.topic-title .sidebar-burger-button,
-.topic-title-with-star .sidebar-burger-button {
-  display: none;
-  margin-right: var(--spacing-2);
-}
-
-.sidebar-toggle-bar {
-  display: flex;
-  justify-content: flex-end;
-  padding: var(--spacing-2) var(--spacing-3);
-  position: sticky;
-  top: var(--nav-height);
-  z-index: 10;
-  background: var(--color-bg-sidebar);
-  border-bottom: var(--border-width) solid var(--color-border);
-}
-
-.sidebar-burger-button {
-  border: none;
-  background: var(--color-bg-card);
-  color: var(--color-text-secondary);
-  width: 32px;
-  height: 32px;
-  border-radius: 999px;
-  box-shadow: var(--shadow-sm);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 14px;
-  transition: transform var(--transition-fast), background-color var(--transition-fast);
-  z-index: 1;
-}
-
-.sidebar-burger-button:hover {
-  background: var(--color-bg-hover);
-  transform: scale(1.05);
-}
-
-
-@media (max-width: 900px) {
-  .sidebar-toggle-bar {
-    display: none;
-  }
-}
 
 @media (max-width: 720px) {
   .layout-sidebar-resizer {

--- a/app/assets/stylesheets/components/topics.css
+++ b/app/assets/stylesheets/components/topics.css
@@ -86,10 +86,6 @@
   font-size: var(--font-size-base);
 }
 
-body.sidebar-collapsed .topics-table th.topic-title .sidebar-burger-button {
-  display: inline-flex;
-}
-
 .topics-table {
   & table {
     width: 100%;

--- a/app/assets/stylesheets/layouts/topic-view.css
+++ b/app/assets/stylesheets/layouts/topic-view.css
@@ -13,10 +13,6 @@
   margin-top: var(--spacing-4);
 }
 
-body.sidebar-collapsed .topic-title-with-star .sidebar-burger-button {
-  display: inline-flex;
-}
-
 .topic-title-section {
   margin-bottom: var(--spacing-5);
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -132,9 +132,6 @@ html data-theme="light"
     - if content_for?(:sidebar)
       .page-layout.with-sidebar data-sidebar-target="layout"
         .layout-sidebar#layout-sidebar data-sidebar-target="sidebar" data-action="click->sidebar#closeOnNavigate"
-          .sidebar-toggle-bar
-            button.sidebar-burger-button type="button" aria-label="Toggle sidebar" data-action="click->sidebar#toggle"
-              i.fa-solid.fa-bars aria-hidden="true"
           = yield :sidebar
         .layout-sidebar-resizer data-sidebar-target="resizer" role="separator" aria-orientation="vertical" aria-label="Resize sidebar" data-action="mousedown->sidebar#startResize touchstart->sidebar#startResize"
         .layout-sidebar-overlay data-sidebar-target="overlay" data-action="click->sidebar#closeMobile"

--- a/app/views/topics/index.html.slim
+++ b/app/views/topics/index.html.slim
@@ -7,8 +7,6 @@
       thead
         tr
           th.topic-title
-            button.sidebar-burger-button type="button" aria-label="Expand sidebar" data-action="click->sidebar#toggle"
-              i.fa-solid.fa-bars aria-hidden="true"
             | Topic
           th.mailing-lists-header Mailing Lists
           th.activity-header Activity

--- a/app/views/topics/show.html.slim
+++ b/app/views/topics/show.html.slim
@@ -169,8 +169,6 @@
 .topic-header
   .topic-title-section
     .topic-title-with-star
-      button.sidebar-burger-button type="button" aria-label="Expand sidebar" data-action="click->sidebar#toggle"
-        i.fa-solid.fa-bars aria-hidden="true"
       - if user_signed_in?
         = render "star_button", topic: @topic, starred: @is_starred
       h1 = @topic.title


### PR DESCRIPTION
The header burger now uses sidebar#toggleMobile, which already correctly routes to collapse()/expand() on desktop and the slide-in drawer on mobile.

Unified view, always at the same spot and works from all pages now. 

Resolves #110