### PR TITLE
Add user setting to collapse quoted text in messages

### DIFF
--- a/app/controllers/settings/preferences_controller.rb
+++ b/app/controllers/settings/preferences_controller.rb
@@ -13,7 +13,7 @@ module Settings
     private
 
     def preferences_params
-      params.require(:user).permit(:mention_restriction, :open_threads_at_first_unread, :collapse_read_messages)
+      params.require(:user).permit(:mention_restriction, :open_threads_at_first_unread, :collapse_read_messages, :collapse_quotes)
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,7 +55,8 @@ module ApplicationHelper
   end
 
   def render_message_body(body)
-    QuotedEmailFormatter.new(body.to_s).to_html.html_safe
+    collapse_quotes = user_signed_in? && current_user.collapse_quotes?
+    QuotedEmailFormatter.new(body.to_s, collapse_quotes: collapse_quotes).to_html.html_safe
   end
 
   def message_dom_id(message)

--- a/app/lib/quoted_email_formatter.rb
+++ b/app/lib/quoted_email_formatter.rb
@@ -8,16 +8,22 @@ class QuotedEmailFormatter
     %r{\Ahttps?://postgr\.es/m/([^?#\s]+)}i
   ].freeze
 
-  def initialize(body)
+  def initialize(body, collapse_quotes: false)
     normalized = body.to_s.gsub("\r\n", "\n").gsub("\r", "\n")
     @lines = normalized.split("\n")
+    @collapse_quotes = collapse_quotes
     @reference_map = extract_reference_links(@lines)
   end
 
   def to_html
     parsed = parse_lines
-    trailing_start = find_trailing_quote_start(parsed)
-    build_html(parsed, trailing_start)
+    ranges = if @collapse_quotes
+      quote_section_ranges(parsed)
+    else
+      trailing_start = find_trailing_quote_start(parsed)
+      trailing_start ? [ trailing_start..(parsed.length - 1) ] : []
+    end
+    build_html(parsed, ranges)
   end
 
   private
@@ -74,18 +80,60 @@ class QuotedEmailFormatter
     text.strip.match?(HEADER_REGEX)
   end
 
-  def build_html(lines, trailing_start_idx)
+  # Each section is a maximal run of quoted lines (blank lines between quoted
+  # lines stay inside), extended to include an immediately preceding
+  # "On ... wrote:" header line.
+  def quote_section_ranges(lines)
+    ranges = []
+    idx = 0
+    while idx < lines.length
+      unless lines[idx][:depth].positive?
+        idx += 1
+        next
+      end
+
+      start_idx = idx
+      last_quote_idx = idx
+      scan = idx + 1
+      while scan < lines.length && (lines[scan][:depth].positive? || lines[scan][:blank])
+        last_quote_idx = scan if lines[scan][:depth].positive?
+        scan += 1
+      end
+
+      header_idx = start_idx - 1
+      if header_idx >= 0 && lines[header_idx][:depth].zero? && quote_header?(lines[header_idx][:text])
+        start_idx = header_idx
+      end
+
+      ranges << (start_idx..last_quote_idx)
+      idx = last_quote_idx + 1
+    end
+    ranges
+  end
+
+  def build_html(lines, collapse_ranges)
     html = +""
     buffer = []
     current_depth = 0
-    collapse_started = false
+    range_starts = collapse_ranges.to_h { |range| [ range.begin, range ] }
+    open_range = nil
 
     lines.each_with_index do |line, idx|
-      if trailing_start_idx && idx == trailing_start_idx && !collapse_started
+      if open_range && idx > open_range.end
+        flush_buffer(buffer, html, quoted: current_depth.positive?)
+        while current_depth.positive?
+          html << "</blockquote>\n"
+          current_depth -= 1
+        end
+        html << "</details>\n"
+        open_range = nil
+      end
+
+      if (range = range_starts[idx])
         flush_buffer(buffer, html, quoted: current_depth.positive?)
         html << %(<details class="quoted-block">\n)
         html << %(<summary>Show quoted text</summary>\n)
-        collapse_started = true
+        open_range = range
       end
 
       new_depth = line[:depth]
@@ -116,7 +164,7 @@ class QuotedEmailFormatter
       current_depth -= 1
     end
 
-    html << "</details>" if collapse_started
+    html << "</details>" if open_range
     html
   end
 

--- a/app/views/settings/profiles/show.html.slim
+++ b/app/views/settings/profiles/show.html.slim
@@ -45,4 +45,9 @@
             span.radio-text
               strong Collapse read messages
               span.radio-description Automatically collapse already-read messages when opening a thread
+          label
+            = f.check_box :collapse_quotes
+            span.radio-text
+              strong Collapse quoted text
+              span.radio-description Collapse all quoted text in message bodies behind a "Show quoted text" toggle
       = f.submit "Save", class: "button-primary"

--- a/db/migrate/20260611120000_add_collapse_quotes_to_users.rb
+++ b/db/migrate/20260611120000_add_collapse_quotes_to_users.rb
@@ -1,0 +1,5 @@
+class AddCollapseQuotesToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :collapse_quotes, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_03_180000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_11_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -767,6 +767,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_03_180000) do
     t.boolean "open_threads_at_first_unread", default: false, null: false
     t.datetime "last_login_at"
     t.boolean "collapse_read_messages", default: true, null: false
+    t.boolean "collapse_quotes", default: false, null: false
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["person_id"], name: "index_users_on_person_id"
     t.index ["username"], name: "index_users_on_username", unique: true

--- a/spec/lib/quoted_email_formatter_spec.rb
+++ b/spec/lib/quoted_email_formatter_spec.rb
@@ -102,5 +102,103 @@ RSpec.describe QuotedEmailFormatter do
 
       expect(html).to include(resolver_path)
     end
+
+    it "collapses only trailing quoted text by default" do
+      body = <<~BODY
+        On Mon, Jun 1, 2026 Alice wrote:
+        > first quoted point
+
+        Reply to the first point.
+
+        > second quoted point
+
+        Reply to the second point.
+      BODY
+
+      html = described_class.new(body).to_html
+
+      expect(html.scan(/quoted-block/).size).to eq(0)
+      expect(html.scan(/<blockquote>/).size).to eq(2)
+    end
+
+    it "still collapses trailing quoted text by default" do
+      body = <<~BODY
+        My reply up top.
+
+        On Mon, Jun 1, 2026 Alice wrote:
+        > trailing quote
+      BODY
+
+      html = described_class.new(body).to_html
+
+      expect(html.scan(/quoted-block/).size).to eq(1)
+    end
+  end
+
+  describe "#to_html with collapse_quotes" do
+    it "wraps every quoted section in a collapsible details block" do
+      body = <<~BODY
+        On Mon, Jun 1, 2026 Alice wrote:
+        > first quoted point
+
+        Reply to the first point.
+
+        > second quoted point
+
+        Reply to the second point.
+      BODY
+
+      html = described_class.new(body, collapse_quotes: true).to_html
+
+      expect(html.scan(/<details class="quoted-block">/).size).to eq(2)
+      expect(html.scan(%r{<summary>Show quoted text</summary>}).size).to eq(2)
+      expect(html.scan(%r{</details>}).size).to eq(2)
+      # unquoted replies stay outside the collapsed blocks
+      expect(html).to include("Reply to the first point.")
+      expect(html).to include("Reply to the second point.")
+    end
+
+    it "pulls the quote attribution header into the collapsed block" do
+      body = <<~BODY
+        On Mon, Jun 1, 2026 Alice wrote:
+        > quoted point
+
+        My reply.
+      BODY
+
+      html = described_class.new(body, collapse_quotes: true).to_html
+
+      header_idx = html.index("Alice wrote:")
+      details_idx = html.index("<details")
+      expect(details_idx).to be < header_idx
+    end
+
+    it "keeps blank-line-separated quoted runs in one collapsed section" do
+      body = <<~BODY
+        > first paragraph of quote
+
+        > second paragraph of quote
+
+        Single reply.
+      BODY
+
+      html = described_class.new(body, collapse_quotes: true).to_html
+
+      expect(html.scan(/<details class="quoted-block">/).size).to eq(1)
+    end
+
+    it "produces well-formed nesting for nested quotes" do
+      body = <<~BODY
+        >> grandparent text
+        > parent text
+
+        Reply.
+      BODY
+
+      html = described_class.new(body, collapse_quotes: true).to_html
+
+      expect(html.scan(/<blockquote>/).size).to eq(html.scan(%r{</blockquote>}).size)
+      expect(html.scan(/<details/).size).to eq(html.scan(%r{</details>}).size)
+    end
   end
 end

--- a/spec/requests/collapse_quotes_rendering_spec.rb
+++ b/spec/requests/collapse_quotes_rendering_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Collapse quotes rendering", type: :request do
+  let(:body_with_inline_quote) do
+    <<~BODY
+      On Mon, Jun 1, 2026 Alice wrote:
+      > inline quoted point
+
+      Reply to the inline quote.
+    BODY
+  end
+
+  let!(:topic) { create(:topic) }
+  let!(:message) { create(:message, topic: topic, body: body_with_inline_quote) }
+
+  context "when signed out" do
+    it "renders inline quotes uncollapsed" do
+      get topic_path(topic)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).not_to include("quoted-block")
+      expect(response.body).to include("<blockquote>")
+    end
+  end
+
+  context "when signed in with collapse_quotes off (default)" do
+    it "renders inline quotes uncollapsed" do
+      sign_in_as(create(:user))
+
+      get topic_path(topic)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).not_to include("quoted-block")
+    end
+  end
+
+  context "when signed in with collapse_quotes on" do
+    it "wraps quoted text in a collapsible block" do
+      sign_in_as(create(:user, collapse_quotes: true))
+
+      get topic_path(topic)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include('<details class="quoted-block">')
+      expect(response.body).to include("<summary>Show quoted text</summary>")
+      expect(response.body).to include("Reply to the inline quote.")
+    end
+  end
+end

--- a/spec/requests/settings/preferences_spec.rb
+++ b/spec/requests/settings/preferences_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Settings::Preferences", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in_as(user) }
+
+  describe "PATCH /settings/preferences" do
+    it "defaults collapse_quotes to off for new users" do
+      expect(user.collapse_quotes).to be(false)
+    end
+
+    it "enables collapse_quotes" do
+      patch settings_preferences_path, params: { user: { collapse_quotes: "1" } }
+
+      expect(response).to redirect_to(settings_profile_path)
+      expect(user.reload.collapse_quotes).to be(true)
+    end
+
+    it "disables collapse_quotes" do
+      user.update!(collapse_quotes: true)
+
+      patch settings_preferences_path, params: { user: { collapse_quotes: "0" } }
+
+      expect(response).to redirect_to(settings_profile_path)
+      expect(user.reload.collapse_quotes).to be(false)
+    end
+  end
+
+  describe "GET /settings/profile" do
+    it "shows the collapse quotes preference unchecked by default" do
+      get settings_profile_path
+
+      expect(response.body).to include("Collapse quoted text")
+      checkbox = response.body.scan(/<input[^>]+>/).find do |tag|
+        tag.include?("user[collapse_quotes]") && tag.include?('type="checkbox"')
+      end
+      expect(checkbox).to be_present
+      expect(checkbox).not_to include("checked")
+    end
+  end
+end

--- a/spec/system/collapse_quotes_spec.rb
+++ b/spec/system/collapse_quotes_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# End-to-end browser flow for the collapse-quotes preference. The feature is
+# fully server-rendered (native <details> elements), so the rack_test driver
+# exercises the complete login -> settings -> thread flow without JS.
+RSpec.describe "Collapse quotes setting", type: :system do
+  before { driven_by(:rack_test) }
+
+  let(:email) { "tester@example.com" }
+  let(:password) { "secret-password" }
+
+  let!(:user) do
+    user = create(:user, username: "tester", password: password)
+    al = create(:alias, user: user, email: email, verified_at: Time.current)
+    user.person.update!(default_alias_id: al.id)
+    user
+  end
+
+  let(:message_body) do
+    <<~BODY
+      On Mon, Jun 1, 2026 Alice wrote:
+      > inline quoted point
+
+      Reply to the inline quote.
+    BODY
+  end
+
+  let!(:topic) { create(:topic) }
+  let!(:message) { create(:message, topic: topic, body: message_body) }
+
+  def sign_in
+    visit new_session_path
+    fill_in "Email", with: email
+    fill_in "Password", with: password
+    click_button "Log In"
+    expect(page).to have_content("Signed in successfully")
+  end
+
+  it "is off by default and collapses quotes once enabled from settings" do
+    sign_in
+
+    # Default: setting is off, quotes render uncollapsed
+    visit settings_profile_path
+    expect(page).to have_unchecked_field("user[collapse_quotes]")
+
+    visit topic_path(topic)
+    expect(page).to have_no_css("details.quoted-block")
+    expect(page).to have_css("blockquote", text: "inline quoted point")
+
+    # Enable the setting through the real form
+    visit settings_profile_path
+    check "user[collapse_quotes]"
+    click_button "Save", exact: true
+    expect(page).to have_content("Preferences updated")
+    expect(page).to have_checked_field("user[collapse_quotes]")
+
+    # Quotes are now collapsed behind a "Show quoted text" toggle
+    visit topic_path(topic)
+    expect(page).to have_css("details.quoted-block summary", text: "Show quoted text")
+    expect(page).to have_content("Reply to the inline quote.")
+
+    # Turn it back off and confirm old behavior returns
+    visit settings_profile_path
+    uncheck "user[collapse_quotes]"
+    click_button "Save", exact: true
+
+    visit topic_path(topic)
+    expect(page).to have_no_css("details.quoted-block")
+  end
+end


### PR DESCRIPTION
## What

Adds an opt-in user preference — **off by default** — that collapses *every* quoted section of a message body behind a native `<details>` "Show quoted text" toggle, instead of only the trailing quote block.

Since pgsql-hackers convention is bottom-posting, threads with long quoted context force a lot of scrolling to find the actual replies. With this setting on, the unquoted reply text stays visible while each quoted run (including its "On ... wrote:" attribution line) collapses into its own toggle.

## How

- `QuotedEmailFormatter` accepts a `collapse_quotes:` option and generalizes the existing trailing-quote collapse into arbitrary collapse ranges (`quote_section_ranges`). Default behavior (trailing-only collapse) is byte-for-byte unchanged.
- New `users.collapse_quotes` boolean column, default `false`, `NOT NULL`.
- Checkbox on `/settings/profile` under **Thread Display**, persisted via `Settings::PreferencesController`.
- Reuses the existing `.quoted-block` styling — no CSS or JS changes needed (native `<details>`).

## Screenshot

With the setting enabled, both quoted sections in a bottom-posted reply collapse while the replies stay visible:

(see thread view: `▶ Show quoted text` toggles between visible reply paragraphs)

## Testing

- Formatter unit specs: collapse-all mode, attribution header pulled into the block, blank-line-separated quote runs grouped, balanced nesting, and regression coverage that default mode still collapses only trailing quotes.
- Request specs: preference toggling + default-off checkbox, and topic rendering signed-out / setting-off / setting-on.
- Capybara system spec driving the full flow: log in → settings shows the option unchecked → thread renders quotes uncollapsed → enable via the form → quotes collapse → disable → old behavior returns.
- Full suite: **841 examples, 0 failures** (baseline before the change: 827/0).
- Manually verified against the running dev stack (seeded thread, toggled the setting via the real form, confirmed rendered HTML and screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)