### PR TITLE
fix z-index of left icons, to comply with the right ones

### DIFF
--- a/app/assets/stylesheets/components/topics.css
+++ b/app/assets/stylesheets/components/topics.css
@@ -192,6 +192,7 @@ a.topic-icon {
 .status-border {
   border-left: 8px solid transparent;
   position: relative;
+  overflow: visible;
 }
 
 .topic-title-main,
@@ -399,6 +400,7 @@ a.topic-icon {
   align-items: center;
   gap: var(--spacing-2);
   position: relative;
+  z-index: 2;
   padding: var(--spacing-2) var(--spacing-4) var(--spacing-2) var(--spacing-2);
   align-self: stretch;
   height: 100%;
@@ -424,7 +426,7 @@ a.topic-icon {
   position: absolute;
   top: calc(100% + 6px);
   left: 0;
-  z-index: 20;
+  z-index: 50;
   background: var(--color-bg-hoverbox);
   border-radius: var(--border-radius-md);
   padding: var(--spacing-3);


### PR DESCRIPTION
## Summary
- Restores a z-index fix that was made on a branch (`z-index`, commit baffc37c) but never merged into main, so the popover hover box on topic-row icons has been rendering below/behind adjacent content — especially visible on Safari.
- A complementary fix (#54) landed separately around the same time (row gets `z-index: 5` while a popover is open), but the matching bump on `.topic-icon-hover` itself and its container never made it in.

Restores:
- `overflow: visible` on `.status-border`
- `z-index: 2` on `.topic-title-icons`
- `.topic-icon-hover` bumped from `z-index: 20` to `z-index: 50`

## Test plan
- [ ] Hover topic-list icons (left side) and confirm the popover renders in front of subsequent rows on Chrome/Windows and Safari/macOS