### PR TITLE
Add default "Ignored by me" saved search

### DIFF
--- a/db/migrate/20260805100000_seed_ignored_by_me_saved_search.rb
+++ b/db/migrate/20260805100000_seed_ignored_by_me_saved_search.rb
@@ -1,0 +1,12 @@
+class SeedIgnoredByMeSavedSearch < ActiveRecord::Migration[8.0]
+  def up
+    SavedSearch.find_or_create_by!(name: "Ignored by me", scope: "user", user_id: nil, team_id: nil) do |s|
+      s.query = "ignored:me"
+      s.position = 5
+    end
+  end
+
+  def down
+    SavedSearch.where(name: "Ignored by me", scope: "user", user_id: nil, team_id: nil).destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_28_141138) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_05_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"


### PR DESCRIPTION
## Summary
- Seeds a default `SavedSearch` template ("Ignored by me", query `ignored:me`) for signed-in users, mirroring the existing `starred:me` seed.
- Follow-up to #117, which added `ignored:me` as a working search selector but never seeded it as a default filter/template the way starring got one, so users had no out-of-the-box way to discover it.

## Test plan
- [ ] Run `bin/rails db:migrate` and confirm a "Ignored by me" entry appears under the user templates section in Settings > Saved Searches and in the topic sidebar for signed-in users.
- [ ] Confirm `ignored:me` still returns only ignored topics when used via the new default filter.