### PR TITLE
Change `padding-top` value of `topic-title-text`

### DIFF
--- a/app/assets/stylesheets/components/topics.css
+++ b/app/assets/stylesheets/components/topics.css
@@ -176,6 +176,10 @@ a.topic-icon {
   }
 }
 
+.topic-title-text {
+  padding-top: var(--spacing-2);
+}
+
 /* specificity beats the mobile .topic-icon margin reset */
 .topic-title-text .topic-title-ignore {
   margin: 0 var(--spacing-2) 0 0;


### PR DESCRIPTION
Aligns the topic title with buttons on the left side
I might be tripping, but I think the "ignore thread" button is not pixel-perfect aligned