### PR TITLE
Add `max-width` for `people` and `teams_profile` show views

### DIFF
--- a/app/assets/stylesheets/components/profile.css
+++ b/app/assets/stylesheets/components/profile.css
@@ -1,3 +1,9 @@
+.person-container {
+  max-width: var(--max-width-container);
+  margin: 0 auto;
+  padding: var(--spacing-6);
+}
+
 .person-profile {
   display: flex;
   flex-direction: column;
@@ -435,7 +441,7 @@ a.summary-box:hover {
 
 .team-badge {
   padding: 2px 8px;
-  border-radius: var(--border-radius-full);
+  border-radius: var(--border-radius-sm);
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-semibold);
 }
@@ -455,10 +461,17 @@ a.summary-box:hover {
   color: var(--color-success-text);
 }
 
+.team-container {
+  max-width: var(--max-width-container);
+  margin: 0 auto;
+  padding: var(--spacing-6);
+}
+
 .team-profile {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-6);
+  padding: var(--spacing-4);
 }
 
 .team-profile .profile-header {

--- a/app/views/people/show.html.slim
+++ b/app/views/people/show.html.slim
@@ -26,31 +26,32 @@
       - else
         p No additional aliases.
 
-.person-profile
-  .profile-header
-    .profile-avatar
-      = image_tag @primary_alias&.gravatar_url(size: 120), class: "profile-avatar-image", alt: @person.display_name
-    .profile-details
-      h1.profile-name = @person.display_name
-      - if @primary_alias
-        p.profile-email = @primary_alias.email
-      - if @person.contributor_memberships.any?
-        - badge = @primary_alias&.contributor_badge || @person.contributor_badge
-        - if badge.present?
-          span.profile-badge = badge
+.person-container
+  .person-profile
+    .profile-header
+      .profile-avatar
+        = image_tag @primary_alias&.gravatar_url(size: 120), class: "profile-avatar-image", alt: @person.display_name
+      .profile-details
+        h1.profile-name = @person.display_name
+        - if @primary_alias
+          p.profile-email = @primary_alias.email
+        - if @person.contributor_memberships.any?
+          - badge = @primary_alias&.contributor_badge || @person.contributor_badge
+          - if badge.present?
+            span.profile-badge = badge
 
-  = render "stats"
+    = render "stats"
 
-  - message_panel = capture do
-    = turbo_frame_tag "person-activity" do
-      = render "activity_filters"
-      .profile-section
-        = render "contributions"
-      = render "recent_threads"
+    - message_panel = capture do
+      = turbo_frame_tag "person-activity" do
+        = render "activity_filters"
+        .profile-section
+          = render "contributions"
+        = render "recent_threads"
 
-  - commit_frame_options = { src: person_commits_path(@profile_email, week_start: WeekCalculation.week_start_param(@week_start_day)) }
-  - commit_frame_options[:loading] = "lazy" unless @active_tab == :commits
-  - commit_panel = capture do
-    = turbo_frame_tag "person-commit-activity", **commit_frame_options
+    - commit_frame_options = { src: person_commits_path(@profile_email, week_start: WeekCalculation.week_start_param(@week_start_day)) }
+    - commit_frame_options[:loading] = "lazy" unless @active_tab == :commits
+    - commit_panel = capture do
+      = turbo_frame_tag "person-commit-activity", **commit_frame_options
 
-  = render "shared/profile/activity_tabs", active: @active_tab, panels: [{ key: :messages, label: "Email activity", body: message_panel }, { key: :commits, label: "Commit activity", body: commit_panel }]
+    = render "shared/profile/activity_tabs", active: @active_tab, panels: [{ key: :messages, label: "Email activity", body: message_panel }, { key: :commits, label: "Commit activity", body: commit_panel }]

--- a/app/views/teams_profile/show.html.slim
+++ b/app/views/teams_profile/show.html.slim
@@ -21,33 +21,34 @@
       - else
         p No members yet.
 
-.team-profile
-  .profile-header
-    .profile-details
-      h1.profile-name = @team.name
-      .team-visibility
-        - case @team.visibility
-        - when "private"
-          span.team-badge.badge-private Private team
-        - when "visible"
-          span.team-badge.badge-visible Visible team
-        - when "open"
-          span.team-badge.badge-open Open team
-      p.profile-meta
-        = pluralize(@members.count, 'member')
+.team-container
+  .team-profile
+    .profile-header
+      .profile-details
+        h1.profile-name = @team.name
+        .team-visibility
+          - case @team.visibility
+          - when "private"
+            span.team-badge.badge-private Private team
+          - when "visible"
+            span.team-badge.badge-visible Visible team
+          - when "open"
+            span.team-badge.badge-open Open team
+        p.profile-meta
+          = pluralize(@members.count, 'member')
 
-  = render "stats"
+    = render "stats"
 
-  - message_panel = capture do
-    = turbo_frame_tag "team-activity" do
-      = render "activity_filters"
-      .profile-section
-        = render "contributions"
-      = render "recent_threads"
+    - message_panel = capture do
+      = turbo_frame_tag "team-activity" do
+        = render "activity_filters"
+        .profile-section
+          = render "contributions"
+        = render "recent_threads"
 
-  - commit_frame_options = { src: team_commits_path(@team.name, week_start: WeekCalculation.week_start_param(@week_start_day)) }
-  - commit_frame_options[:loading] = "lazy" unless @active_tab == :commits
-  - commit_panel = capture do
-    = turbo_frame_tag "team-commit-activity", **commit_frame_options
+    - commit_frame_options = { src: team_commits_path(@team.name, week_start: WeekCalculation.week_start_param(@week_start_day)) }
+    - commit_frame_options[:loading] = "lazy" unless @active_tab == :commits
+    - commit_panel = capture do
+      = turbo_frame_tag "team-commit-activity", **commit_frame_options
 
-  = render "shared/profile/activity_tabs", active: @active_tab, panels: [{ key: :messages, label: "Email activity", body: message_panel }, { key: :commits, label: "Commit activity", body: commit_panel }]
+    = render "shared/profile/activity_tabs", active: @active_tab, panels: [{ key: :messages, label: "Email activity", body: message_panel }, { key: :commits, label: "Commit activity", body: commit_panel }]


### PR DESCRIPTION
I really like the way `CI` nad `Notification` pages looks like right now and I think we should add a `max-width` attribute to more pages.

This PR adds `.person-container` and `.team-container` classes.