### PR TITLE
Mark activities as read only when you click on it

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -10,7 +10,6 @@ class ActivitiesController < ApplicationController
                     .includes(subject: [ :topic, { message: :sender } ])
                     .order(created_at: :desc)
                     .limit(100)
-    mark_shown_as_read!(@activities)
     @unread_count = base_scope.unread.count
   end
 
@@ -19,7 +18,24 @@ class ActivitiesController < ApplicationController
     redirect_to activities_path, notice: "Marked all as read"
   end
 
+  def read
+    activity = base_scope.find(params[:id])
+    activity.mark_read! if activity.read_at.nil?
+    redirect_to path_for_subject(activity.subject)
+  end
+
   private
+
+  def path_for_subject(subject)
+    case subject
+    when Note
+      topic_path(subject.topic, anchor: subject.message_id ? helpers.message_dom_id(subject.message) : "thread-notes")
+    when Message
+      topic_path(subject.topic, anchor: helpers.message_dom_id(subject))
+    else
+      activities_path
+    end
+  end
 
   def base_scope
     current_user.activities.visible
@@ -35,11 +51,5 @@ class ActivitiesController < ApplicationController
                          .where("messages.body ILIKE ? OR messages.subject ILIKE ?", "%#{@search_query}%", "%#{@search_query}%")
 
     Activity.from("(#{note_query.to_sql} UNION #{message_query.to_sql}) AS activities")
-  end
-
-  def mark_shown_as_read!(activities)
-    unread_ids = activities.select { |a| a.read_at.nil? }.map(&:id)
-    return if unread_ids.empty?
-    Activity.where(id: unread_ids).update_all(read_at: Time.current)
   end
 end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -20,7 +20,8 @@ class ActivitiesController < ApplicationController
 
   def read
     activity = base_scope.find(params[:id])
-    activity.mark_read! if activity.read_at.nil?
+    related_activities = base_scope.where(subject: activity.subject)
+    related_activities.mark_all_as_read!
     redirect_to path_for_subject(activity.subject)
   end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -8,4 +8,8 @@ class Activity < ApplicationRecord
   def mark_read!
     update!(read_at: Time.current)
   end
+
+  def self.mark_all_as_read!
+    self.where(read_at: nil).update_all(read_at: Time.current)
+  end
 end

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -24,7 +24,7 @@
           - if subject.is_a?(Note)
             .activity-body
               .activity-title
-                = link_to subject.topic.title, read_activity_path(activity), data: { turbo_method: :post }
+                = link_to subject.topic.title, read_activity_path(activity)
               .activity-snippet = truncate(subject.body, length: 160)
               - if subject.note_tags.any?
                 .activity-tags
@@ -36,7 +36,7 @@
           - elsif subject.is_a?(Message)
             .activity-body
               .activity-title
-                = link_to subject.topic.title, read_activity_path(activity), data: { turbo_method: :post }
+                = link_to subject.topic.title, read_activity_path(activity)
               .activity-snippet
                 strong> = subject.subject
                 = truncate(subject.body, length: 140)

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -24,7 +24,7 @@
           - if subject.is_a?(Note)
             .activity-body
               .activity-title
-                = link_to(subject.topic.title, topic_path(subject.topic, anchor: subject.message_id ? message_dom_id(subject.message) : "thread-notes"))
+                = link_to subject.topic.title, read_activity_path(activity), data: { turbo_method: :post }
               .activity-snippet = truncate(subject.body, length: 160)
               - if subject.note_tags.any?
                 .activity-tags
@@ -36,7 +36,7 @@
           - elsif subject.is_a?(Message)
             .activity-body
               .activity-title
-                = link_to(subject.topic.title, topic_path(subject.topic, anchor: message_dom_id(subject)))
+                = link_to subject.topic.title, read_activity_path(activity), data: { turbo_method: :post }
               .activity-snippet
                 strong> = subject.subject
                 = truncate(subject.body, length: 140)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,7 @@ Rails.application.routes.draw do
   end
   resources :activities, only: [ :index ] do
     post :mark_all_read, on: :collection
+    post :read, on: :member
   end
   resources :notes, only: [ :create, :update, :destroy ]
   resources :note_mentions, only: [ :destroy ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,7 +100,7 @@ Rails.application.routes.draw do
   end
   resources :activities, only: [ :index ] do
     post :mark_all_read, on: :collection
-    post :read, on: :member
+    get :read, on: :member
   end
   resources :notes, only: [ :create, :update, :destroy ]
   resources :note_mentions, only: [ :destroy ]


### PR DESCRIPTION
Rigth now all activities are being marked as `read` when we visit `/activities`. This patch changes it so activity is marked as `read` only when we click on it or when we use `Mark all read` button.

#131 