### PR TITLE
Remove `activity-types` class from `_commit_table`

### DIFF
--- a/app/views/shared/profile/_commit_table.html.slim
+++ b/app/views/shared/profile/_commit_table.html.slim
@@ -17,7 +17,7 @@
         - commit_rows.each do |row|
           - commit = row[:commit]
           tr
-            td.activity-types
+            td
               - if show_members
                 - row[:member_credits].each do |credit|
                   - member_alias = credit[:person].default_alias

--- a/spec/requests/team_commits_spec.rb
+++ b/spec/requests/team_commits_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'Team commit activity', type: :request do
       rows = doc.css('table.commit-activity-table tbody tr')
       expect(rows.size).to eq(1)
 
-      credits = rows.first.css('td.activity-types .commit-member-credit')
+      credits = rows.first.css('td .commit-member-credit')
       expect(credits.size).to eq(2)
 
       # one tuple per member: separate per-attribute lists would still pass if


### PR DESCRIPTION
It fixes the bottom border for `Credit` column.

Before:
<img width="1538" height="1001" alt="Screenshot 2026-09-03 at 08 08 20" src="https://github.com/user-attachments/assets/67c0f383-39f6-4045-8bfc-1a4aa42e18b9" />
After:
<img width="1552" height="988" alt="Screenshot 2026-09-03 at 08 07 49" src="https://github.com/user-attachments/assets/bd2d7c61-398c-4ddb-a543-2c50d9b11ea5" />
